### PR TITLE
adding explicit type to DataTableDirectives so typescript lint does not complain anymore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ jspm_packages
 .idea
 lib
 build
+*.iml
 

--- a/mf-angular2-table/datatable.d.ts
+++ b/mf-angular2-table/datatable.d.ts
@@ -3,4 +3,4 @@ export {DefaultSorter} from './lib/DefaultSorter';
 export {Paginator} from './lib/Paginator';
 export {BootstrapPaginator} from './lib/BootstrapPaginator';
 
-export const DataTableDirectives;
+export const DataTableDirectives: any[];


### PR DESCRIPTION
adding explicit type to DataTableDirectives so typescript lint does not complain anymore

It was issuing problems with some gulp builds