### PR TITLE
Removed AOT compilation incompatible "private" visibility modifiers

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,10 +35,7 @@
   },
   "homepage": "https://github.com/mariuszfoltak/angular2-datatable#readme",
   "devDependencies": {
-    "@angular/core": "^2.1.0",
     "@angular/compiler": "^2.1.0",
-    "@angular/common": "^2.1.0",
-    "@angular/platform-browser": "^2.1.0",
     "@angular/platform-browser-dynamic": "^2.1.0",
     "@angular/compiler-cli": "^2.1.0",
     "core-js": "^2.4.1",
@@ -49,11 +46,10 @@
     "karma-coverage": "^0.5.5",
     "karma-jasmine": "^0.3.8",
     "karma-phantomjs-launcher": "^1.0.0",
-    "lodash": "^4.0.0",
     "phantomjs-prebuilt": "^2.1.7",
     "reflect-metadata": "^0.1.8",
     "remap-istanbul": "^0.6.3",
-    "rxjs": "^5.0.0-beta.12",
+    "rxjs": "5.0.0-beta.12",
     "systemjs": "^0.19.39",
     "traceur": "0.0.108",
     "typescript": "^2.0.0",
@@ -62,9 +58,9 @@
     "@types/jasmine": "^2.5.35"
   },
   "dependencies": {
-    "@angular/core": "^2.0.0",
-    "@angular/common": "^2.0.0",
-    "@angular/platform-browser": "^2.0.0",
+    "@angular/core": "^2.1.0",
+    "@angular/common": "^2.1.0",
+    "@angular/platform-browser": "^2.1.0",
     "lodash": "^4.0.0"
   },
   "peerDependencies": {

--- a/src/BootstrapPaginator.ts
+++ b/src/BootstrapPaginator.ts
@@ -1,6 +1,5 @@
 import {Component, Input, OnChanges} from "@angular/core";
 import {DataTable} from "./DataTable";
-import {Paginator} from "./Paginator";
 import * as _ from "lodash";
 
 @Component({
@@ -51,10 +50,10 @@ import * as _ from "lodash";
     `
 })
 export class BootstrapPaginator implements OnChanges {
-    @Input("rowsOnPageSet") private rowsOnPageSet = [];
-    @Input("mfTable") private mfTable: DataTable;
+    @Input("rowsOnPageSet") rowsOnPageSet = [];
+    @Input("mfTable") mfTable: DataTable;
 
-    private minRowsOnPage = 0;
+    minRowsOnPage = 0;
 
     ngOnChanges(changes:any):any {
         if(changes.rowsOnPageSet) {

--- a/src/DefaultSorter.ts
+++ b/src/DefaultSorter.ts
@@ -11,7 +11,7 @@ import {DataTable, SortEvent} from "./DataTable";
         </a>`
 })
 export class DefaultSorter {
-    @Input("by") private sortBy: string;
+    @Input("by") sortBy: string;
 
     private isSortedByMeAsc: boolean = false;
     private isSortedByMeDesc: boolean = false;

--- a/src/Paginator.ts
+++ b/src/Paginator.ts
@@ -8,7 +8,7 @@ import {DataTable, PageEvent} from "./DataTable";
 export class Paginator implements OnChanges {
 
     @Input("mfTable")
-    private inputMfTable:DataTable;
+    inputMfTable:DataTable;
 
     private mfTable:DataTable;
 


### PR DESCRIPTION
Removed private on @Input fields and fields used in templates so typescript compilation after AOT compilation doesn't emit errors anymore

Example of such an error : 

> error TS2341: Property 'sortBy' is private and only accessible within class 'DefaultSorter'.