### PR TITLE
@angular dependencies as peerDependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "typescript": "~2.1.0",
     "zone.js": "^0.6.25",
     "rimraf": "^2.5.4",
-    "@types/lodash": "^4.14.37",
+    "@types/lodash": "ts2.0",
     "@types/jasmine": "^2.5.35"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -61,12 +61,12 @@
     "@types/jasmine": "^2.5.35"
   },
   "dependencies": {
-    "@angular/core": "^2.0.0",
-    "@angular/common": "^2.0.0",
-    "@angular/platform-browser": "^2.0.0",
     "lodash": "^4.0.0"
   },
   "peerDependencies": {
+    "@angular/core": "^2.0.0",
+    "@angular/common": "^2.0.0",
+    "@angular/platform-browser": "^2.0.0",
     "rxjs": "^5.0.0-beta.12"
   }
 }


### PR DESCRIPTION
With newer angular versions the compilation of angular2-datatable fails, because of AOT incompatibilites.
Changing the `@angular` dependencies to peerDependencies resolves this.

For more details, see point 8 from: https://medium.com/@isaacplmann/making-your-angular-2-library-statically-analyzable-for-aot-e1c6f3ebedd5#.wmaqchqya


EDIT:
Seems there was a second issue, that `@types/lodash` was not ts2.0 compatible anymore.