### PR TITLE
Update peerDependencies to support Angular 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,9 +64,9 @@
     "lodash": "^4.0.0"
   },
   "peerDependencies": {
-    "@angular/core": "^2.0.0",
-    "@angular/common": "^2.0.0",
-    "@angular/platform-browser": "^2.0.0",
+    "@angular/core": "^2.0.0||^4.0.0",
+    "@angular/common": "^2.0.0||^4.0.0",
+    "@angular/platform-browser": "^2.0.0||^4.0.0",
     "rxjs": "^5.0.0-beta.12"
   }
 }


### PR DESCRIPTION
This avoids warnings when using angular2-datatable with the latest stable version of Angular.
We should possibly also update the devDependencies, but it's not as crucial as these are not giving any warnings.