### PR TITLE
fixed error when changing page

### DIFF
--- a/src/DataTable.ts
+++ b/src/DataTable.ts
@@ -145,7 +145,7 @@ export class DataTable implements OnChanges, DoCheck {
         } else {
             data = _.orderBy(data, sortBy, [this.sortOrder]);
         }
-        data = _.slice(data, offset, offset + this.rowsOnPage);
+        data = _.slice(data, offset, offset + parseInt(this.rowsOnPage.toString()));
         this.data = data;
     }
 


### PR DESCRIPTION
fillData function was assuming this.rowsOnPage as string in `data = _.slice(data, offset, offset + this.rowsOnPage)`. causing error when change page in paginator